### PR TITLE
描画負荷を減らす

### DIFF
--- a/game.js
+++ b/game.js
@@ -128,6 +128,8 @@ Vue.createApp({
       time:0,
       diff:0,
 
+      fps:60,
+      rendertime:0,
 
     }
   },
@@ -182,6 +184,20 @@ Vue.createApp({
 
     configshowmult(){
       this.showmult = !this.showmult
+    },
+    configfps(){
+      if (this.fps >= 60)
+        this.fps = 10
+      else if (this.fps >= 10)
+        this.fps = 1
+      else
+        this.fps = 60
+    },
+    currenttimeid(){
+      return Math.floor(Date.now() * this.fps * 0.001) * 1000 + this.rendertime
+    },
+    rerender(){
+      this.rendertime = (this.rendertime + 1) % 1000
     },
     softCap(num,cap){
       if(num.lessThanOrEqualTo(cap)) return num;
@@ -387,7 +403,7 @@ Vue.createApp({
 
       let diffm = this.diff
       this.diff = Date.now()-this.time-this.player.tickspeed
-      console.log(this.diff+this.player.tickspeed)
+      // console.log(this.diff+this.player.tickspeed)
       this.time = Date.now()
       this.activechallengebonuses = (this.player.challengebonuses.includes(4) || !this.player.onchallenge)?this.player.challengebonuses:[]
 
@@ -668,6 +684,7 @@ Vue.createApp({
         if(!this.player.onchallenge || this.player.challengebonuses.includes(4))this.activechallengebonuses = this.player.challengebonuses
       this.calcaccost()
       this.calcdgcost()
+      this.rerender()
     },
     changeTab(tabname){
       this.player.currenttab = tabname;
@@ -857,6 +874,7 @@ Vue.createApp({
           this.players[i] = initialData()
         }
       }
+      this.rerender()
     },
     calcgainlevel(){
       let dividing = 19-this.player.rank.add(2).log2()
@@ -951,7 +969,7 @@ Vue.createApp({
         if(this.activechallengebonuses.includes(1))this.player.accelerators[0] = new Decimal(10)
         if(this.player.rankchallengebonuses.includes(0))this.player.money = this.player.money.add(new Decimal("1e9"))
         if(this.player.rankchallengebonuses.includes(1))this.player.accelerators[0] = this.player.accelerators[0].add(256)
-
+        this.rerender()
       }
     },
     calcgainrank(){
@@ -1030,7 +1048,7 @@ Vue.createApp({
         if(this.activechallengebonuses.includes(1))this.player.accelerators[0] = new Decimal(10)
         if(this.player.rankchallengebonuses.includes(0))this.player.money = this.player.money.add(new Decimal("1e9"))
         if(this.player.rankchallengebonuses.includes(1))this.player.accelerators[0] = this.player.accelerators[0].add(256)
-
+        this.rerender()
       }
     },
     calcchallengeid(){
@@ -1119,6 +1137,7 @@ Vue.createApp({
             new Decimal(10).pow(this.player.generatorsBought[i].add(i + 1).mul(i + 1))
           }
         }
+        this.rerender()
       }
     },
     gettrophyname(i){

--- a/index.html
+++ b/index.html
@@ -10,14 +10,14 @@
 <body>
 　<div id="app">
 		<div class="container" v-cloak>
-			<div id="coinamount">ポイント: {{ player.money.toExponential(3) }}</div>
-			<div id="tickspeed">
+			<div id="coinamount" v-memo="[currenttimeid(), world]">ポイント: {{ player.money.toExponential(3) }}</div>
+			<div id="tickspeed" v-memo="[currenttimeid(), world]">
 				間隙: {{ Math.round(player.tickspeed) }}毛秒
 				<span v-if="player.accelerators[0].gt(0)">
 					時間加速器効果: {{ (1000/player.tickspeed).toFixed(3) }} 倍
 				</span>
 			</div>
-			<div class="tabs">
+			<div class="tabs" v-memo="[currenttimeid(), world, player.currenttab]">
 				<span id="basic">
           <button type="button" @click="changeTab('basic')">通常</button>
         </span>
@@ -46,7 +46,7 @@
 					<button type="button" @click="changeTab('trophy')">実績</button>
 				</span>
 			</div>
-			<div class="basictabcontents" v-show="player.currenttab == 'basic'">
+			<div class="basictabcontents" v-show="player.currenttab == 'basic'" v-memo="[currenttimeid(), world, player.currenttab]">
 				<div class="levelrcontents" v-if="player.levelresettime.gt(0)">
 					段位: {{ toFormated(player.level,5) }} 段位リセット: {{ toFormated(player.levelresettime,5) }}回
 				</div>
@@ -70,6 +70,7 @@
 				<br>
 				<div>
 					<button type="button" @click="configshowmult()">倍率を表示/非表示</button>
+					<button type="button" @click="configfps()">描画頻度を変更</button>{{ fps }}fps
 				</div>
 				<div class="generators-container">
 					<div class="generator" v-for="i in 8" :key="i">
@@ -136,7 +137,7 @@
 						</button>
 					</div>
 			</div>
-			<div v-show= "player.currenttab == 'dark'">
+			<div v-show= "player.currenttab == 'dark'" v-memo="[currenttimeid(), world, player.currenttab]">
 				<div id="darkcoinamount" v-show="player.rankchallengecleared.length>=32">裏ポイント: {{ player.darkmoney.toExponential(3) }}</div>
 				裏発生器iは発生器iを強化します。
 				<div v-show = "player.rankchallengecleared.length>=32">裏発生器は、煌きを消費すると発生器のように動作し、裏ポイントや下位の裏発生器を生み出します。裏ポイントは全ての発生器を強化します。</div>
@@ -152,7 +153,7 @@
 					</span>
 				</div>
 			</div>
-			<div v-show="player.currenttab == 'option'">
+			<div v-show="player.currenttab == 'option'" v-memo="[currenttimeid(), world, player.currenttab]">
 				<button type="button" id="resetbutton" @click="resetData(false)">リセット</button>
         <div class="tweetconfig">
           ツイート機能設定
@@ -177,7 +178,7 @@
 					<button type="button" id="importsave" @click="importsave()">データ取り込み</button>
 				</div>
 			</div>
-      <div v-show="player.currenttab == 'level'">
+      <div v-show="player.currenttab == 'level'" v-memo="[currenttimeid(), world, player.currenttab]">
 				最大取得段位:{{ toFormated(player.maxlevelgained,5) }}
 				<div class="challenges-container">
           挑戦:挑戦とは厳しい条件で昇段リセットを目指すことです。
@@ -252,7 +253,7 @@
 					</div>
 				</div>
 			</div>
-			<div v-show="player.currenttab == 'rank'">
+			<div v-show="player.currenttab == 'rank'" v-memo="[currenttimeid(), world, player.currenttab]">
 				<div class="levelshop">
 					段位捧所:段位捧所では、段位を消費することによって強化を購入することができます。
 					段位を捧げた回数に応じて、捧げるべき段位の量が少なくなります。
@@ -268,7 +269,7 @@
 					累計購入回数: {{player.levelitembought}}
 				</div>
 			</div>
-			<div v-show="player.currenttab == 'auto'">
+			<div v-show="player.currenttab == 'auto'" v-memo="[currenttimeid(), world, player.currenttab]">
 				自動購入器設定
 				<div v-if="player.challengebonuses.includes(5)">
 					<button type="button" class="autobuyerbutton" :class="{ 'selected': genautobuy }" @click="toggleautobuyer(0)">
@@ -308,7 +309,7 @@
 					消費輝き: {{ 1000 - checkremembers()*10 }}
 				</div>
 			</div>
-			<div v-show="player.currenttab == 'shine'">
+			<div v-show="player.currenttab == 'shine'" v-memo="[currenttimeid(), world, player.currenttab]">
 				<div>
 				輝き所持数:{{ player.shine }}
 					<button type="button" class="spendshinebutton"  @click="spendshine(1)">
@@ -355,7 +356,7 @@
 					<div>最大煌き保有数: {{ shinedata.getmaxbr(player.rankchallengecleared.length)　}}</div>
 				</div>
 			</div>
-			<div v-show="player.currenttab == 'world'">
+			<div v-show="player.currenttab == 'world'" v-memo="[currenttimeid(), world, player.currenttab]">
 				記憶: {{ memory }}
 				<div>
 					記憶は、他世界での実績の個数の合計です。記憶が多くなるほど、発生器の生産量が増加します。
@@ -390,7 +391,7 @@
 					</div>
 				</div>
 			</div>
-			<div v-show="player.currenttab == 'trophy'">
+			<div v-show="player.currenttab == 'trophy'" v-memo="[currenttimeid(), world, player.currenttab]">
 				<button type="button" @click="checktrophies()">
 					実績更新
 				</button>


### PR DESCRIPTION
描画頻度を変更できるようにしてみました。参考にしてください。

通常タブのボタンで描画頻度を変更（60fps→10fps→1fps→60fps）できます。
データロード、リセット、挑戦開始、世界移動時には強制的に再描画されるようにしました。